### PR TITLE
Fixed typo in commented code

### DIFF
--- a/gigasecond/src/test/scala/gigasecond_test.scala
+++ b/gigasecond/src/test/scala/gigasecond_test.scala
@@ -24,6 +24,6 @@ class GigasecondTests extends FunSuite with Matchers {
     pending
     // val yourBirthday = new GregorianCalendar(year, month-1, day)
     // val gs = Gigasecond(yourBirthday)
-    // gs.date should be (GregorianCalendar(2009, 0, 31))
+    // gs.date should be (new GregorianCalendar(2009, 0, 31))
   }
 }


### PR DESCRIPTION
There was a small typo in the code commented in the Gigasecond exercise where you would test for your own birthday's gigasecond date. The code forgot to use `new`.
