### PR TITLE
Cleanup atbash-cipher example

### DIFF
--- a/atbash-cipher/example.scala
+++ b/atbash-cipher/example.scala
@@ -4,7 +4,6 @@ case class Atbash() {
 
   private def substitute(c: Char) =
     if (c.isDigit) c.toString
-    else if(c.isLetter) ('a'.toInt + ('z'.toInt - c.toLower.toInt)).toChar.toString
+    else if (c.isLetter) ('a' + ('z' - c.toLower)).toChar.toString
     else ""
-
 }


### PR DESCRIPTION
Remove unneeded casts from char to int
