### PR TITLE
fixed duplicate test

### DIFF
--- a/roman-numerals/src/test/scala/roman_numerals_test.scala
+++ b/roman-numerals/src/test/scala/roman_numerals_test.scala
@@ -50,10 +50,6 @@ class RomanNumeralsSpecs extends FunSpec with Matchers {
     RomanNumeral(93).value should be ("XCIII")
   }
 
-  it ("93 equals XCIII") {
-    RomanNumeral(93).value should be ("XCIII")
-  }
-
   it ("141 equals CXLI") {
     RomanNumeral(141).value should be ("CXLI")
   }


### PR DESCRIPTION
Fix for removing duplicate test, which causes this error:

org.scalatest.exceptions.DuplicateTestNameException: Duplicate test name: 93 equals XCIII
