### PR TITLE
Make hamming conform to official definition

### DIFF
--- a/hamming/example.scala
+++ b/hamming/example.scala
@@ -1,4 +1,7 @@
 class Hamming(strand1: String, strand2: String) {
+	
+  require(strand1.length == strand2.length)
+
   def distance = commonPairs.count {
     case (a, b) => a != b
   }

--- a/hamming/src/test/scala/hamming_test.scala
+++ b/hamming/src/test/scala/hamming_test.scala
@@ -30,13 +30,10 @@ class HammingSpecs extends FlatSpec with Matchers {
     Hamming.compute("ACCAGGG", "ACTATGG") should be (2)
   }
 
-  it should "ignore extra length on other strand when longer" in {
+  it should "be undefined for strands of unequal length" in {
     pending
-    Hamming.compute("AAACTAGGGG", "AGGCTAGCGGTAGGAC") should be (3)
-  }
-
-  it should "ignore extra length on original strand when longer" in {
-    pending
-    Hamming.compute("GACTACGGACAGGGTAGGGAAT", "GACATCGCACACC") should be (5)
+    an[IllegalArgumentException] should be thrownBy {
+      Hamming.compute("AAACTAGGGG", "AGGCTAGCGGTAGGAC")
+    }
   }
 }


### PR DESCRIPTION
Closes #14

I opted for the `IllegalArgumentException` because this is only exercise 2 of the scala track so requiring the concept of `PartialFunctions` seemed a bit too much. I also thought about going with a return type of `Option[Int]` however I felt like Strings of unequal length are not a common input when trying to calculate the Hamming distance so the required match on the result is almost always unnecessary. Also, an exception is imo  easier to understand than the difference between a `None` and `Some(0)` result from a semantics point of view.