### PR TITLE
Run scalatest on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
-language: bash
+language: scala
+scala:
+  - 2.10.3
+
+before_script:
+  - bin/fetch-configlet
+  - sbt test:compile
 
 script:
-  - bin/fetch-configlet
   - bin/configlet .
+  - sbt test

--- a/bank-account/src/test/scala/BankAccountTest.scala
+++ b/bank-account/src/test/scala/BankAccountTest.scala
@@ -1,7 +1,7 @@
-import org.scalatest.concurrent.Conductors
+import org.scalatest.concurrent.{IntegrationPatience, Conductors}
 import org.scalatest.{Matchers, FunSuite}
 
-class BankAccountTest extends FunSuite with Matchers with Conductors{
+class BankAccountTest extends FunSuite with Matchers with Conductors with IntegrationPatience {
   test("open account") {
     BankAccount().getBalance should be (Some(0))
   }

--- a/config.json
+++ b/config.json
@@ -69,7 +69,9 @@
 
   ],
   "ignored": [
-    "docs"
+    "docs",
+    "project",
+    "target"
   ],
   "foregone": [
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,0 +1,54 @@
+import java.io.File
+
+import sbt.Keys._
+import sbt._
+
+import scala.io.Source
+import scala.util.parsing.json.{JSONArray, JSONObject, JSON}
+
+object ThisBuild extends Build {
+
+  scalaVersion := "2.10.3"
+  name := "xscala"
+
+  val commonSettings = Seq(
+    updateOptions := updateOptions.value.withCachedResolution(true),
+
+    (unmanagedSources in Test) <<= (unmanagedSources in Test, sourceManaged in Test) map {
+      case (testSources, managedTestDir) =>
+        copyTestsAndStripPending(testSources, managedTestDir)
+    }
+  )
+
+  override def projects: Seq[Project] = {
+    fetchProblemNames("config.json").map {
+      problemName => Project(problemName, new File(problemName)).settings(commonSettings:_*)
+    }
+  }
+
+  def copyTestsAndStripPending(tests: Seq[File], managedSourceDir: File): Seq[File] = {
+    tests.map { originalTestFile =>
+      val filename = originalTestFile.name
+      val newTestFile = managedSourceDir / filename
+      IO.writeLines(newTestFile, IO.readLines(originalTestFile).filter(_.trim != "pending"))
+      newTestFile
+    }
+  }
+
+  def fetchProblemNames(configJsonFile: String): Seq[String] = {
+    val configStr = Source.fromFile(configJsonFile, "UTF-8").getLines().mkString
+    val configObj = JSON
+      .parseRaw(configStr)
+      .map(_.asInstanceOf[JSONObject].obj)
+      .getOrElse {
+        throw new IllegalArgumentException(s"Could not parse $configJsonFile as JSON")
+      }
+    configObj
+      .get("problems")
+      .map(_.asInstanceOf[JSONArray].list)
+      .getOrElse {
+        throw new IllegalArgumentException(s"Could not find array 'problems' in $configJsonFile")
+      }
+      .collect { case problem: String => problem }
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8


### PR DESCRIPTION
So here is my proposal for getting all the tests to execute on Travis CI (see #2) by defining a sbt multi-project that aggregates all the other projects. 

It is maybe not the most elegant way, but I couldn't figure out how to dynamically define all problems as subprojects in the `build.sbt` and therefore used the *old* way of defining the build in `Build.scala`. An alternative would be to let Travis write a `build.sbt` on the fly.

A little script is also removing all the pending statements before tests are being executed. 

The only issue I found was in the `BankAccount` problem, where the timing sensitive test failed because of a timeout. The issue here is most likely that the Scalatest Testrunner executes the tests in all project in parallel which means individual tests run slower compared to being run in isolation.