### PR TITLE
Make nucleotide-count example and tests more scaly

### DIFF
--- a/nucleotide-count/example.scala
+++ b/nucleotide-count/example.scala
@@ -1,26 +1,16 @@
 class DNA(strand: String) {
-  strand.foreach(validate)
+  strand foreach validate
 
-  def count(nucleotide: Char) = {
-    validate(nucleotide)
-    strand.count(_ == nucleotide)
+  lazy val nucleotideCounts = {
+    Map('A' -> 0, 'T' -> 0, 'C' -> 0, 'G' -> 0) ++
+    strand.toCharArray.groupBy(identity).mapValues(_.length)
   }
 
-  def nucleotideCounts = Map(
-    'A' -> count('A'),
-    'T' -> count('T'),
-    'C' -> count('C'),
-    'G' -> count('G')
-  )
-
   private def validate(nucleotide: Char) =
-    if (!isNucleotide(nucleotide))
-      throw new IllegalArgumentException
-
-  private def isNucleotide(nucleotide: Char) =
-    DNA.nucleotides.contains(nucleotide)
+    if (!DNA.isNucleotide(nucleotide)) throw new IllegalArgumentException
 }
 
 object DNA {
   val nucleotides = "ATCG"
+  def isNucleotide(c: Char) = nucleotides.contains(c)
 }

--- a/nucleotide-count/src/test/scala/nucleotide_count_test.scala
+++ b/nucleotide-count/src/test/scala/nucleotide_count_test.scala
@@ -1,8 +1,8 @@
 import org.scalatest._
 
 class NucleotideCountSpecs extends FlatSpec with Matchers {
-  "empty dna string" should "have no adenosine" in {
-    new DNA("").count('A') should be (0)
+  "empty dna string" should "have no adenine" in {
+    new DNA("").nucleotideCounts('A') should be (0)
   }
 
   it should "have no nucleotides" in {
@@ -11,56 +11,50 @@ class NucleotideCountSpecs extends FlatSpec with Matchers {
     new DNA("").nucleotideCounts should be (expected)
   }
 
-  "a repetitive sequence" should "count cytidine" in {
+  "a repetitive sequence" should "count cytosine" in {
     pending
-    new DNA("CCCCC").count('C') should be (5)
+    new DNA("CCCCC").nucleotideCounts('C') should be (5)
   }
 
-  it should "have only guanosine" in {
+  it should "have only guanine" in {
     pending
     val expected = Map('A' -> 0, 'T' -> 0, 'C' -> 0, 'G' -> 8)
     new DNA("GGGGGGGG").nucleotideCounts should be (expected)
   }
 
-  "a mixed dna string" should "count only thymidine" in {
+  "a mixed dna string" should "count only thymine" in {
     pending
-    new DNA("GGGGGTAACCCGG").count('T') should be (1)
+    new DNA("GGGGGTAACCCGG").nucleotideCounts('T') should be (1)
   }
 
   it should "count a nucleotide only once" in {
     pending
     val dna = new DNA("CGATTGGG")
-    dna.count('T')
-    dna.count('T') should be (2)
+    dna.nucleotideCounts('T')
+    dna.nucleotideCounts('T') should be (2)
   }
 
-  it should "not change counts after counting adenosine" in {
+  it should "not change counts after counting adenine" in {
     pending
     val dna = new DNA("GATTACA")
-    dna.count('A')
+    dna.nucleotideCounts('A')
     val expected = Map('A' -> 3, 'T' -> 2, 'C' -> 1, 'G' -> 1)
     dna.nucleotideCounts should be (expected)
   }
 
   it should "validate nucleotides" in {
     pending
-    evaluating {
-      new DNA("GACT").count('X')
-    } should produce [IllegalArgumentException]
+    a [RuntimeException] should be thrownBy new DNA("GACT").nucleotideCounts('X')
   }
 
   it should "validate dna not rna" in {
     pending
-    evaluating {
-      new DNA("ACGU")
-    } should produce [IllegalArgumentException]
+    a [RuntimeException] should be thrownBy new DNA("ACGU")
   }
 
   it should "validate dna" in {
     pending
-    evaluating {
-      new DNA("John")
-    } should produce [IllegalArgumentException]
+    a [RuntimeException] should be thrownBy new DNA("John")
   }
 
   it should "count all nucleotides" in {


### PR DESCRIPTION
 - Made nucleotidesCount a lazy val instead of a def in example solution. The return result would never change, but was running through validation and counting every time it was called.
 - Replaced deprecated exception syntax in test suite.
 - Changed nucleotide terms in test suite from ribonucleoside form to nucleobase form (i.e. adenosine to adenine) to be consistent with terms used in exercise readme.
 - Removed test suite's insistence that solution provide two different members that, in Scala, do the same thing (count vs. nucleotideCounts). This insistence, along with specifically requiring an InvalidArgumentException, railroads solutions towards too small a possible set. All calls to count are replaced with calls to nucleotideCounts, because Scala maps already provide the functionality of count (except that it throws a NoSuchElementException instead of an IAE), and the test now only expects that SOME RuntimeException be thrown, rather than an IAE specifically, allowing solvers to judge for themselves if the added specificity of a separate accessor that translates the map's NSEE to an IAE is worth the verbosity.