### PR TITLE
acronym: fixed typos, crypto-square: upgraded scala version

### DIFF
--- a/acronym/example.scala
+++ b/acronym/example.scala
@@ -1,5 +1,5 @@
-case class Acroynm(phrase: String) {
-  def abberviate: String = {
+case class Acronym(phrase: String) {
+  def abbreviate: String = {
     "[A-Z]+[a-z]*|[a-z]+".r.findAllIn(phrase).map(s => s.head.toUpper).mkString
   }
 }

--- a/acronym/src/test/scala/AcronymTest.scala
+++ b/acronym/src/test/scala/AcronymTest.scala
@@ -10,6 +10,6 @@ class AcronymTest extends FlatSpec with Matchers {
     ("Complementary metal-oxide semiconductor", "CMOS"))
 
   it should "create acronyms" in {
-    acronyms.foreach{case (phrase, acronym) => Acroynm(phrase).abberviate should equal(acronym)}
+    acronyms.foreach{case (phrase, acronym) => Acronym(phrase).abbreviate should equal(acronym)}
   }
 }

--- a/crypto-square/build.sbt
+++ b/crypto-square/build.sbt
@@ -1,3 +1,3 @@
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.7"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test"


### PR DESCRIPTION
acronym: fix for two typos in class and function name
crypto-square: upgraded Scala version