### PR TITLE
largest-series-product: Do not test digits/slices

### DIFF
--- a/exercises/largest-series-product/example.scala
+++ b/exercises/largest-series-product/example.scala
@@ -1,7 +1,7 @@
 object Series {
-  def digits(s: String): List[Int] = s.map(c => c.asDigit).toList
+  private def digits(s: String): List[Int] = s.map(c => c.asDigit).toList
 
-  def slices(n: Int, s: String): List[List[Int]] = {
+  private def slices(n: Int, s: String): List[List[Int]] = {
     assert(n >= 0, "slice length must be non-negative")
     digits(s).tails.filter(xs => xs.length >= n).map(xs => xs.take(n)).toList
   }

--- a/exercises/largest-series-product/src/test/scala/SeriesTest.scala
+++ b/exercises/largest-series-product/src/test/scala/SeriesTest.scala
@@ -1,25 +1,6 @@
 import org.scalatest.{Matchers, FlatSpec}
 
 class SeriesTest extends FlatSpec with Matchers {
-  it should "map digits" in {
-    Series.digits(('0' to '9').mkString) should equal (0 to 9)
-    Series.digits(('0' to '9').reverse.mkString) should equal ((0 to 9).reverse)
-    Series.digits(('4' to '8').reverse.mkString) should equal ((4 to 8).reverse)
-    Series.digits("936923468") should equal (List(9, 3, 6, 9, 2, 3, 4, 6, 8))
-  }
-
-  it should "slice" in {
-    Series.slices(2, "98273463") should equal(List(List(9, 8), List(8, 2),
-      List(2, 7), List(7, 3), List(3, 4), List(4, 6), List(6, 3)))
-    Series.slices(3, "982347") should equal(List(List(9, 8, 2), List(8, 2, 3),
-      List(2, 3, 4), List(3, 4, 7)))
-  }
-
-  it should "slice boundary conditions" in {
-    Series.slices(4, "982") should equal(List())
-    Series.slices(3, "982") should equal(List(List(9, 8, 2)))
-  }
-
   it should "find largestProduct" in {
     Series.largestProduct(2, "0123456789") should equal(Some(72))
     Series.largestProduct(2, "19") should equal(Some(9))


### PR DESCRIPTION
The digits and slices functions are internal implementation details and
thus the test case for the largest-series-product problem should not be
concerned with testing them. The series tests could potentially be moved
to the series exercise (already implemented by this track).

Their presence may cause students to falsely think that their solution
has to use these two functions, instead of the alternative
implementation of only iterating through the digits once.

If it is desired to give hints on how to approach this problem (which
was one advantage of having the digits and slices tests), then consider
including a hints file and/or directory in the largest-series-product
directory.

This PR arises from discussion in
https://github.com/exercism/x-common/issues/192