### PR TITLE
Change regex from \w to [A-Z]

### DIFF
--- a/exercises/robot-name/src/test/scala/robot_name_test.scala
+++ b/exercises/robot-name/src/test/scala/robot_name_test.scala
@@ -1,7 +1,7 @@
 import org.scalatest._
 
 class RobotNameSpecs extends FunSpec with Matchers {
-  val nameRegex = """\w{2}\d{3}"""
+  val nameRegex = """[A-Z]{2}\d{3}"""
 
   it ("has a name") {
     new Robot().name should fullyMatch regex (nameRegex)


### PR DESCRIPTION
The regex used in the test doesn't explicitly search for the format given in the problem documentation. This makes it explicit that the first two characters need to be an uppercase letter