### PR TITLE
connect: Add missing `mkBoard` call

### DIFF
--- a/exercises/connect/src/test/scala/ConnectTest.scala
+++ b/exercises/connect/src/test/scala/ConnectTest.scala
@@ -11,7 +11,7 @@ class ConnectTest extends FunSuite with Matchers {
                     ,"  . . . . ."
                     ,"   . . . . ."
                     ,"    . . . . .")
-    Connect(lines).result should be (None)
+    Connect(mkBoard(lines)).result should be (None)
   }
 
   test("black single item board") {


### PR DESCRIPTION
It seems that all boards should be passed through `mkBoard` so that the
spaces are removed. The connect README also states that the spaces won't
be in the representation passed to the function under test. So let's do
this for the empty board too.

To be clear, failure to do so probably isn't cauing any solution to
falsely report a winner since there are no pieces on board and the
expected result is None (no winner).

The only problems omission of the `mkBoard` might cause would be if a
solution expects that its inputs either:

* Have no spaces, or
* Are rectangular (this board is 9 spaces wide at the top but 13 at the
  bottom)

So probably nobody noticed this yet, but if someone writes a solution
with either expectation they would notice.