### PR TITLE
sublist: avoid `new Sublist()`

### DIFF
--- a/exercises/sublist/example.scala
+++ b/exercises/sublist/example.scala
@@ -1,20 +1,17 @@
-
-class Sublist[T] {
-  def sublist(l1: List[T], l2: List[T]): Sublist.Value = {
-    if (equal(l1, l2)) Sublist.Equal
-    else if (isSublist(l1, l2)) Sublist.Sublist
-    else if (isSuperlist(l1, l2)) Sublist.Superlist
-    else Sublist.Unequal
+object Sublist extends Enumeration {
+  def sublist[T](l1: List[T], l2: List[T]): Value = {
+    if (equal(l1, l2)) Equal
+    else if (isSublist(l1, l2)) Sublist
+    else if (isSuperlist(l1, l2)) Superlist
+    else Unequal
   }
 
-  private def equal(l1: List[T], l2: List[T]) = l1.equals(l2)
+  private def equal[T](l1: List[T], l2: List[T]) = l1.equals(l2)
 
-  private def isSublist(l1: List[T], l2: List[T]) = l2.containsSlice(l1)
+  private def isSublist[T](l1: List[T], l2: List[T]) = l2.containsSlice(l1)
 
-  private def isSuperlist(l1: List[T], l2: List[T]) = l1.containsSlice(l2)
-}
+  private def isSuperlist[T](l1: List[T], l2: List[T]) = l1.containsSlice(l2)
 
-object Sublist extends Enumeration {
   type SublistType = Value
   val Equal, Sublist, Superlist, Unequal = Value
 }

--- a/exercises/sublist/src/test/scala/sublist_test.scala
+++ b/exercises/sublist/src/test/scala/sublist_test.scala
@@ -2,79 +2,79 @@ import org.scalatest.{FunSuite, Matchers}
 
 class SublistSpecs extends FunSuite with Matchers {
   test("empty lists") {
-    new Sublist().sublist(List(), List()) should be (Sublist.Equal)
+    Sublist.sublist(List(), List()) should be (Sublist.Equal)
   }
 
   test("empty is a sublist of anything") {
-    new Sublist().sublist(List(), List('a', 's', 'd', 'f')) should be (Sublist.Sublist)
+    Sublist.sublist(List(), List('a', 's', 'd', 'f')) should be (Sublist.Sublist)
   }
 
   test("anything is a superlist of empty") {
-    new Sublist().sublist(List('a', 's', 'd', 'f'), List()) should be (Sublist.Superlist)
+    Sublist.sublist(List('a', 's', 'd', 'f'), List()) should be (Sublist.Superlist)
   }
 
   test("List(1) is not List(2)") {
-    new Sublist().sublist(List(1), List(2)) should be (Sublist.Unequal)
+    Sublist.sublist(List(1), List(2)) should be (Sublist.Unequal)
   }
 
   test("compare larger equal lists") {
     val xs = List.fill(1000)("x")
-    new Sublist().sublist(xs, xs) should be (Sublist.Equal)
+    Sublist.sublist(xs, xs) should be (Sublist.Equal)
   }
 
   test("sublist at start") {
-    new Sublist().sublist(List(1, 2, 3), List(1, 2, 3, 4, 5)) should be (Sublist.Sublist)
+    Sublist.sublist(List(1, 2, 3), List(1, 2, 3, 4, 5)) should be (Sublist.Sublist)
   }
 
   test("sublist in middle") {
-    new Sublist().sublist(List(4, 3, 2), List(5, 4, 3, 2, 1)) should be (Sublist.Sublist)
+    Sublist.sublist(List(4, 3, 2), List(5, 4, 3, 2, 1)) should be (Sublist.Sublist)
   }
 
   test("sublist at end") {
-    new Sublist().sublist(List(3, 4, 5), List(1, 2, 3, 4, 5)) should be (Sublist.Sublist)
+    Sublist.sublist(List(3, 4, 5), List(1, 2, 3, 4, 5)) should be (Sublist.Sublist)
   }
 
   test("partially matching sublist at start") {
-    new Sublist().sublist(List(1, 1, 2), List(1, 1, 1, 2)) should be (Sublist.Sublist)
+    Sublist.sublist(List(1, 1, 2), List(1, 1, 1, 2)) should be (Sublist.Sublist)
   }
 
   test("sublist early in huge list") {
     val xs = List.range(1, 1000000)
-    new Sublist().sublist(List(3, 4, 5), xs) should be (Sublist.Sublist)
+    Sublist.sublist(List(3, 4, 5), xs) should be (Sublist.Sublist)
   }
 
   test("huge sublist not in huge list") {
     val l1 = List.range(10, 1000001)
     val l2 = List.range(1, 1000000)
-    new Sublist().sublist(l1, l2) should be (Sublist.Unequal)
+    Sublist.sublist(l1, l2) should be (Sublist.Unequal)
   }
 
   test("superlist at start") {
-    new Sublist().sublist(List(1, 2, 3, 4, 5), List(1, 2, 3)) should be (Sublist.Superlist)
+    Sublist.sublist(List(1, 2, 3, 4, 5), List(1, 2, 3)) should be (Sublist.Superlist)
   }
 
   test("superlist in middle") {
-    new Sublist().sublist(List(5, 4, 3, 2, 1), List(4, 3, 2)) should be (Sublist.Superlist)
+    Sublist.sublist(List(5, 4, 3, 2, 1), List(4, 3, 2)) should be (Sublist.Superlist)
   }
 
   test("superlist at end") {
-    new Sublist().sublist(List(1, 2, 3, 4, 5), List(3, 4, 5)) should be (Sublist.Superlist)
+    Sublist.sublist(List(1, 2, 3, 4, 5), List(3, 4, 5)) should be (Sublist.Superlist)
   }
 
   test("partially matching superlist at start") {
-    new Sublist().sublist(List(1, 1, 1, 2), List(1, 1, 2)) should be (Sublist.Superlist)
+    Sublist.sublist(List(1, 1, 1, 2), List(1, 1, 2)) should be (Sublist.Superlist)
   }
 
   test("superlist early in huge list") {
     val l1 = List.range(1, 1000000)
-    new Sublist().sublist(l1, List(3, 4, 5)) should be (Sublist.Superlist)
+    Sublist.sublist(l1, List(3, 4, 5)) should be (Sublist.Superlist)
   }
 
   test("recurring values sublist") {
-    new Sublist().sublist(List(1, 2, 1, 2, 3), List(1, 2, 3, 1, 2, 1, 2, 3, 2, 1)) should be (Sublist.Sublist)
+    Sublist.sublist(List(1, 2, 1, 2, 3), List(1, 2, 3, 1, 2, 1, 2, 3, 2, 1)) should be (Sublist.Sublist)
   }
 
   test("recurring values unequal") {
-    new Sublist().sublist(List(1, 2, 1, 2, 3), List(1, 2, 3, 1, 2, 3, 2, 3, 2, 1)) should be (Sublist.Unequal)
+    Sublist.sublist(List(1, 2, 1, 2, 3), List(1, 2, 3, 1, 2, 3, 2, 3, 2, 1)) should be (Sublist.Unequal)
   }
 }


### PR DESCRIPTION
Reviewers: I came across the somewhat odd `new Sublist()` when working on this problem. It came across as sufficiently odd that I thought I might like to fix it. However, I'm not sure if this change will cause more problems than it solves, so let's discuss.

A specific question I had: In the example solution, we have extra methods on an `Enumeration` object that also contains the four possible answers. Is that okay? I don't know the answer since I don't know Scala conventions well enough, but I did see such things on submitted solutions for other problems, so it might be okay.

It's not necessarily the case that all submitted solutions will follow this pattern, of course, but it is a possibility to be considered.

Original commit message below this line

---

The tests were constructing a `new Sublist()` but only using it for
calling the `sublist` method - the instance is not otherwise used. In
this case, it seems to be better style to simply put the `sublist`
method on a companion object, so it can be called like
`Sublist.sublist(l1, l2)`.