### PR TITLE
Deprecate binary, hexadecimal, octal and trinary. Add all-your-base

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,19 +26,18 @@
     "sublist",
     "rna-transcription",
     "triangle",
-    "binary",
     "roman-numerals",
     "prime-factors",
     "raindrops",
     "allergies",
     "atbash-cipher",
+    "all-your-base",
     "bank-account",
     "crypto-square",
     "kindergarten-garden",
     "robot-simulator",
     "queen-attack",
     "binary-search-tree",
-    "hexadecimal",
     "largest-series-product",
     "luhn",
     "clock",
@@ -46,8 +45,6 @@
     "house",
     "minesweeper",
     "ocr-numbers",
-    "octal",
-    "trinary",
     "wordy",
     "food-chain",
     "linked-list",
@@ -69,7 +66,10 @@
     "forth"
   ],
   "deprecated": [
-
+    "binary",
+    "hexadecimal",
+    "octal",
+    "trinary"
   ],
   "ignored": [
     "docs",

--- a/exercises/all-your-base/build.sbt
+++ b/exercises/all-your-base/build.sbt
@@ -1,0 +1,3 @@
+scalaVersion := "2.11.8"
+
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test"

--- a/exercises/all-your-base/example.scala
+++ b/exercises/all-your-base/example.scala
@@ -1,0 +1,33 @@
+import scala.annotation.tailrec
+
+object AllYourBase {
+  def rebase(inputBase: Int, inputDigits: List[Int], outputBase: Int): Option[List[Int]] = {
+    if (inputBase < 2 || outputBase < 2 || inputDigits.isEmpty)
+      None
+    else {
+      fromDigits(0, inputBase, inputDigits) match {
+        case None => None
+        case Some(x) => Some(toDigits(outputBase, x, List()))
+      }
+    }
+  }
+
+  @tailrec
+  private def fromDigits(acc: Int, base: Int, digits: List[Int]): Option[Int] = {
+    digits match {
+      case x::xs => if (x >= 0 && x < base)
+                      fromDigits(acc * base + x, base, xs)
+                    else
+                      None
+      case Nil => Option(acc)
+    }
+  }
+
+  @tailrec
+  private def toDigits(base: Int, x: Int, acc: List[Int]): List[Int] = {
+    x match {
+      case 0 => acc
+      case _ => toDigits(base, x / base, x % base :: acc)
+    }
+  }
+}

--- a/exercises/all-your-base/src/test/scala/AllYourBaseTest.scala
+++ b/exercises/all-your-base/src/test/scala/AllYourBaseTest.scala
@@ -1,0 +1,128 @@
+import org.scalatest.{FunSuite, Matchers}
+
+class AllYourBaseTest extends FunSuite with Matchers {
+  test("single bit one to decimal") {
+    AllYourBase.rebase(2, List(1),
+      10) should be (Some(List(1)))
+  }
+
+  test("binary to single decimal") {
+    pending
+    AllYourBase.rebase(2, List(1, 0, 1),
+      10) should be (Some(List(5)))
+  }
+
+  test("single decimal to binary") {
+    pending
+    AllYourBase.rebase(10, List(5),
+      2) should be (Some(List(1 ,0 ,1)))
+  }
+
+  test("binary to multiple decimal") {
+    pending
+    AllYourBase.rebase(2, List(1, 0, 1, 0, 1, 0),
+      10) should be (Some(List(4 ,2)))
+  }
+
+  test("decimal to binary") {
+    pending
+    AllYourBase.rebase(10, List(4, 2),
+      2) should be (Some(List(1 ,0 ,1 ,0 ,1 ,0)))
+  }
+
+  test("trinary to hexadecimal") {
+    pending
+    AllYourBase.rebase(3, List(1, 1, 2, 0),
+      16) should be (Some(List(2 ,10)))
+  }
+
+  test("hexadecimal to trinary") {
+    pending
+    AllYourBase.rebase(16, List(2, 10),
+      3) should be (Some(List(1 ,1 ,2 ,0)))
+  }
+
+  test("15-bit integer") {
+    pending
+    AllYourBase.rebase(97, List(3, 46, 60),
+      73) should be (Some(List(6 ,10 ,45)))
+  }
+
+  test("empty list") {
+    pending
+    AllYourBase.rebase(2, List(),
+      10) should be (None)
+  }
+
+  test("single zero") {
+    pending
+    AllYourBase.rebase(10, List(0),
+      2) should be (Some(List()))
+  }
+
+  test("multiple zeros") {
+    pending
+    AllYourBase.rebase(10, List(0, 0, 0),
+      2) should be (Some(List()))
+  }
+
+  test("leading zeros") {
+    pending
+    AllYourBase.rebase(7, List(0, 6, 0),
+      10) should be (Some(List(4, 2)))
+  }
+
+  test("negative digit") {
+    pending
+    AllYourBase.rebase(2, List(1, -1, 1, 0, 1, 0),
+      10) should be (None)
+  }
+
+  test("invalid positive digit") {
+    pending
+    AllYourBase.rebase(2, List(1, 2, 1, 0, 1, 0),
+      10) should be (None)
+  }
+
+  test("first base is one") {
+    pending
+    AllYourBase.rebase(1, List(),
+      10) should be (None)
+  }
+
+  test("second base is one") {
+    pending
+    AllYourBase.rebase(2, List(1, 0, 1, 0, 1, 0),
+      1) should be (None)
+  }
+
+  test("first base is zero") {
+    pending
+    AllYourBase.rebase(0, List(),
+      10) should be (None)
+  }
+
+  test("second base is zero") {
+    pending
+    AllYourBase.rebase(10, List(7),
+      0) should be (None)
+  }
+
+  test("first base is negative") {
+    pending
+    AllYourBase.rebase(-2, List(1),
+      10) should be (None)
+  }
+
+  test("second base is negative") {
+    pending
+    AllYourBase.rebase(2, List(1),
+      -7) should be (None)
+  }
+
+  test("both bases are negative") {
+    pending
+    AllYourBase.rebase(-2, List(1),
+      -7) should be (None)
+  }
+}


### PR DESCRIPTION
Deprecate binary, hexadecimal, octal and trinary exercises. Add all-your-base