### PR TITLE
changed signature of compute to return Option[Int]

### DIFF
--- a/exercises/hamming/example.scala
+++ b/exercises/hamming/example.scala
@@ -1,10 +1,10 @@
 class Hamming(strand1: String, strand2: String) {
-	
-  require(strand1.length == strand2.length)
 
-  def distance = commonPairs.count {
-    case (a, b) => a != b
-  }
+  def distance =
+    if (strand1.length == strand2.length) {
+      val dist = commonPairs.count { case (a, b) => a != b }
+      Some(dist)
+    } else None
 
   private def commonPairs = strand1.zip(strand2)
 }

--- a/exercises/hamming/src/test/scala/hamming_test.scala
+++ b/exercises/hamming/src/test/scala/hamming_test.scala
@@ -2,38 +2,42 @@ import org.scalatest._
 
 class HammingSpecs extends FlatSpec with Matchers {
   it should "detect no difference between empty strands" in {
-    Hamming.compute("", "") should be (0)
+    Hamming.compute("", "") should be (Some(0))
   }
 
   it should "detect no difference between identical strands" in {
     pending
-    Hamming.compute("GGACTGA", "GGACTGA") should be (0)
+    Hamming.compute("GGACTGA", "GGACTGA") should be (Some(0))
   }
 
   it should "detect complete hamming distance in small strand" in {
     pending
-    Hamming.compute("ACT", "GGA") should be (3)
+    Hamming.compute("ACT", "GGA") should be (Some(3))
   }
 
   it should "give hamming distance in off by one strand" in {
     pending
-    Hamming.compute("GGACGGATTCTG", "AGGACGGATTCT") should be (9)
+    Hamming.compute("GGACGGATTCTG", "AGGACGGATTCT") should be (Some(9))
   }
 
   it should "give small hamming distance in middle somewhere" in {
     pending
-    Hamming.compute("GGACG", "GGTCG") should be (1)
+    Hamming.compute("GGACG", "GGTCG") should be (Some(1))
   }
 
   it should "give a larger distance" in {
     pending
-    Hamming.compute("ACCAGGG", "ACTATGG") should be (2)
+    Hamming.compute("ACCAGGG", "ACTATGG") should be (Some(2))
   }
 
-  it should "be undefined for strands of unequal length" in {
+  it should "be undefined for first String longer" in {
     pending
-    an[IllegalArgumentException] should be thrownBy {
-      Hamming.compute("AAACTAGGGG", "AGGCTAGCGGTAGGAC")
-    }
+    Hamming.compute("AGGCTAGCGGTAGGAC", "AAACTAGGGG") should be (None)
+  }
+
+  it should "be undefined for second String longer" in {
+    pending
+    Hamming.compute("AAACTAGGGG", "AGGCTAGCGGTAGGAC") should be (None)
   }
 }
+


### PR DESCRIPTION
I tried to change example.scala as little as possible.
I also have an [alternative tail-recursive version](https://github.com/exercism/xscala/files/482765/Hamming.scala.zip) that avoids calling "length", but zipping the Strings as before is probably still the more instructive way?!
I was also tempted to remove the "pending" in the tests, but kept them in for now.