### PR TITLE
changed signature of square to return Option

### DIFF
--- a/exercises/grains/build.sbt
+++ b/exercises/grains/build.sbt
@@ -1,3 +1,3 @@
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test"

--- a/exercises/grains/example.scala
+++ b/exercises/grains/example.scala
@@ -10,7 +10,7 @@ object Grains {
     def isValidChessboardSquare(n: Int) =
       1 <= n && n <= ChessboardSquares
 
-    def sq(n: Int): BigInt = {
+    def powerOfTwo(n: Int): BigInt = {
       @tailrec
       def loop(n: Int, acc: BigInt): BigInt =
         if (n == 0) acc
@@ -21,7 +21,7 @@ object Grains {
 
     val pred = (_:Int) - 1
 
-    Option(cbSquare) filter isValidChessboardSquare map pred.andThen(sq)
+    Option(cbSquare) filter isValidChessboardSquare map pred.andThen(powerOfTwo)
   }
 
   def total: Grains =

--- a/exercises/grains/example.scala
+++ b/exercises/grains/example.scala
@@ -1,4 +1,29 @@
+import scala.annotation.tailrec
+
 object Grains {
-  def square(x: Int): BigInt = BigInt(2).pow(x-1)
-  def total = 1.to(64).map(square).sum
+  type Grains = BigInt
+  type ChessboardSquare = Int
+
+  private val ChessboardSquares = 64
+
+  def square(cbSquare: ChessboardSquare): Option[Grains] = {
+    def isValidChessboardSquare(n: Int) =
+      1 <= n && n <= ChessboardSquares
+
+    def sq(n: Int): BigInt = {
+      @tailrec
+      def loop(n: Int, acc: BigInt): BigInt =
+        if (n == 0) acc
+        else loop(n - 1, acc * 2)
+
+      loop(n, 1)
+    }
+
+    val pred = (_:Int) - 1
+
+    Option(cbSquare) filter isValidChessboardSquare map pred.andThen(sq)
+  }
+
+  def total: Grains =
+    (1 to ChessboardSquares) flatMap (square _).andThen(_.toList) sum
 }

--- a/exercises/grains/src/test/scala/grains_test.scala
+++ b/exercises/grains/src/test/scala/grains_test.scala
@@ -2,37 +2,46 @@ import org.scalatest._
 
 class GrainsTest extends FunSuite with Matchers {
   test ("square 1") {
-    Grains.square(1) should be (1)
+    Grains.square(1) should be (Some(1))
   }
 
   test ("square 2") {
     pending
-    Grains.square(2) should be (2)
+    Grains.square(2) should be (Some(2))
   }
 
   test ("square 3") {
     pending
-    Grains.square(3) should be (4)
+    Grains.square(3) should be (Some(4))
   }
 
   test ("square 4") {
     pending
-    Grains.square(4) should be (8)
+    Grains.square(4) should be (Some(8))
   }
 
   test ("square 16") {
     pending
-    Grains.square(16) should be (32768)
+    Grains.square(16) should be (Some(32768))
   }
 
   test ("square 32") {
-    pending
-    Grains.square(32) should be (2147483648L)
+    Grains.square(32) should be (Some(2147483648L))
   }
 
   test ("square 64") {
     pending
-    Grains.square(64) should be (BigInt("9223372036854775808"))
+    Grains.square(64) should be (Some(BigInt("9223372036854775808")))
+  }
+
+  test ("square negative") {
+    pending
+    Grains.square(-1) should be (None)
+  }
+
+  test ("square bigger than 64") {
+    pending
+    Grains.square(65) should be (None)
   }
 
   test ("total grains") {
@@ -40,3 +49,4 @@ class GrainsTest extends FunSuite with Matchers {
     Grains.total should be (BigInt("18446744073709551615"))
   }
 }
+


### PR DESCRIPTION
I have added a helper function `powerOfTwo` that internally calculates the power tail-recursively.
Before it was much simpler: `BigInt(2).pow(x-1)`
We can of course keep this implementation for `powerOfTwo`, too. I just found the tail-recursive version more instructive.