### PR TITLE
attribute the scala icon and mention its copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ Please see the [contributing guide](https://github.com/exercism/x-api/blob/maste
 The MIT License (MIT)
 
 Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+
+## Scala icon
+The Scala icon used on Exercism is inspired by the official Scala logo, which is copyright École Polytechnique Fédérale de Lausanne.


### PR DESCRIPTION
hooray, this is the last step in the penultimate step
in fixing https://github.com/exercism/exercism.io/issues/3112