### PR TITLE
Add tests to Leap exercise

### DIFF
--- a/exercises/leap/src/test/scala/leap_test.scala
+++ b/exercises/leap/src/test/scala/leap_test.scala
@@ -10,6 +10,11 @@ class LeapTest extends FunSuite {
     assert(!Year(1997).isLeap)
   }
 
+  test("an even year") {
+    pending
+    assert(!Year(1986).isLeap)
+  }
+
   test ("century") {
     pending
     assert(!Year(1900).isLeap)
@@ -18,5 +23,10 @@ class LeapTest extends FunSuite {
   test ("exceptional century") {
     pending
     assert(Year(2000).isLeap)
+  }
+
+  test("exceptional century that is no millenium") {
+    pending
+    assert(Year(1600).isLeap)
   }
 }


### PR DESCRIPTION
The former tests made it able to pass with a very faulty implementation
that seems a bit more intuitive if you don't know about leap years; such as:

* Checking for even years except those years divisible by 4
* Checking for milleniums except those centuries divisible by 400