### PR TITLE
new exercise sgf-parsing

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,6 +66,7 @@
     "change",
     "connect",
     "parallel-letter-frequency",
+    "sgf-parsing",
     "acronym",
     "zipper",
     "forth",
@@ -448,6 +449,12 @@
 		},
     {
       "slug": "parallel-letter-frequency",
+      "difficulty": 1,
+      "topics": [
+      ]
+		},
+    {
+      "slug": "sgf-parsing",
       "difficulty": 1,
       "topics": [
       ]

--- a/exercises/sgf-parsing/build.sbt
+++ b/exercises/sgf-parsing/build.sbt
@@ -1,0 +1,7 @@
+scalaVersion := "2.11.8"
+
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test"
+
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
+
+

--- a/exercises/sgf-parsing/example.scala
+++ b/exercises/sgf-parsing/example.scala
@@ -2,8 +2,6 @@ import scala.util.parsing.combinator.RegexParsers
 
 object Sgf extends RegexParsers {
 
-  override val skipWhitespace = false
-
   type Tree[A] = Node[A] // to separate the type from the constructor, cf. Haskell's Data.Tree
   type Forest[A] = List[Tree[A]]
   case class Node[A](rootLabel: A, subForest: Forest[A] = List())
@@ -15,53 +13,53 @@ object Sgf extends RegexParsers {
   // Keys may have multiple values associated with them.
   type SgfNode = Map[String, List[String]]
 
+  override val skipWhitespace = false
+
   private implicit def parseResultToOption[T](parseResult: ParseResult[T]): Option[T] =
     parseResult map (Some(_)) getOrElse None
 
   def parseSgf(text: String): Option[SgfTree] =
     parseAll(sgfGameTree, text)
 
-  private def sgfGameTree: Parser[SgfTree] =
+  private val sgfGameTree: Parser[SgfTree] =
     ("(" ~ rep1(sgfNode) ~ rep(sgfGameTree) ~ ")") ^^ {
       case _ ~ (rootNode::subNodes) ~ subTrees ~ _ =>
         val subNodeForest: List[SgfTree] = subNodes map (Node(_))
         Node(rootNode, subNodeForest ++ subTrees)
     } named "sgfGameTree"
 
-  private def sgfNode: Parser[SgfNode] =
+  private val sgfNode: Parser[SgfNode] =
     ";" ~ (sgfProperty | emptySgfNode) ^^ {
       case _ ~ sgfNode => sgfNode
     } named "sgfNode"
 
-  private def emptySgfNode: Parser[SgfNode] =
-    "" ^^ { _ => Map() }
+  private val emptySgfNode: Parser[SgfNode] =
+    "" ^^ const(Map())
 
   private def sgfProperty: Parser[SgfNode] =
     propIdent ~ propValues ^^ {
       case identifier ~ values => Map(identifier -> values)
     } named "sgfProperty"
 
-  private def propIdent: Parser[String] = "[A-Z]".r named "propIdent"
+  private val propIdent: Parser[String] = "[A-Z]".r named "propIdent"
 
-  private def propValues: Parser[List[String]] = rep1(propValue)
+  private val propValues: Parser[List[String]] = rep1(propValue)
 
-  private def propValue: Parser[String] =
+  private val propValue: Parser[String] =
     "[" ~ rep1(propValuePart) ~ "]" ^^ {
       case _ ~ values ~ _ => values mkString
     } named "propValue"
 
-  private def propValuePart: Parser[String] = {
+  private val propValuePart: Parser[String] = {
     implicit class AsStringParser(self: String) { def p: Parser[String] = self }
     val ignore = const("") _
 
-    def quotedClosingBracket: Parser[String] = "\\]".p map const("]")
-    def quotedNewline: Parser[String] = "\\\n".p map ignore
-    def quotedBackslash: Parser[String] = "\\\\".p map const("\\")
-    def backslash: Parser[String] = "\\".p map ignore
-    def whitespace: Parser[String] = """\s""".r map const(" ")
-    def ident: Parser[String] = "[^]]".r map identity
+    val escapedNewline: Parser[String] = "\\\n".p ^^ ignore
+    val escapedChar: Parser[String] = """\\.""".r ^^ (_.takeRight(1))
+    val whitespace: Parser[String] = """\s""".r ^^ const(" ")
+    val ident: Parser[String] = "[^]]".r
 
-    quotedClosingBracket | quotedNewline | quotedBackslash | backslash | whitespace | ident
+    escapedNewline | escapedChar | whitespace | ident
   }
 
   private def const[A](a: A)(ignore: Any) = a

--- a/exercises/sgf-parsing/example.scala
+++ b/exercises/sgf-parsing/example.scala
@@ -1,0 +1,68 @@
+import scala.util.parsing.combinator.RegexParsers
+
+object Sgf extends RegexParsers {
+
+  override val skipWhitespace = false
+
+  type Tree[A] = Node[A] // to separate the type from the constructor, cf. Haskell's Data.Tree
+  type Forest[A] = List[Tree[A]]
+  case class Node[A](rootLabel: A, subForest: Forest[A] = List())
+
+  // A tree of nodes.
+  type SgfTree = Tree[SgfNode]
+
+  // A node is a property list, each key can only occur once.
+  // Keys may have multiple values associated with them.
+  type SgfNode = Map[String, List[String]]
+
+  private implicit def parseResultToOption[T](parseResult: ParseResult[T]): Option[T] =
+    parseResult map (Some(_)) getOrElse None
+
+  def parseSgf(text: String): Option[SgfTree] =
+    parseAll(sgfGameTree, text)
+
+  private def sgfGameTree: Parser[SgfTree] =
+    ("(" ~ rep1(sgfNode) ~ rep(sgfGameTree) ~ ")") ^^ {
+      case _ ~ (rootNode::subNodes) ~ subTrees ~ _ =>
+        val subNodeForest: List[SgfTree] = subNodes map (Node(_))
+        Node(rootNode, subNodeForest ++ subTrees)
+    } named "sgfGameTree"
+
+  private def sgfNode: Parser[SgfNode] =
+    ";" ~ (sgfProperty | emptySgfNode) ^^ {
+      case _ ~ sgfNode => sgfNode
+    } named "sgfNode"
+
+  private def emptySgfNode: Parser[SgfNode] =
+    "" ^^ { _ => Map() }
+
+  private def sgfProperty: Parser[SgfNode] =
+    propIdent ~ propValues ^^ {
+      case identifier ~ values => Map(identifier -> values)
+    } named "sgfProperty"
+
+  private def propIdent: Parser[String] = "[A-Z]".r named "propIdent"
+
+  private def propValues: Parser[List[String]] = rep1(propValue)
+
+  private def propValue: Parser[String] =
+    "[" ~ rep1(propValuePart) ~ "]" ^^ {
+      case _ ~ values ~ _ => values mkString
+    } named "propValue"
+
+  private def propValuePart: Parser[String] = {
+    implicit class AsStringParser(self: String) { def p: Parser[String] = self }
+    val ignore = const("") _
+
+    def quotedClosingBracket: Parser[String] = "\\]".p map const("]")
+    def quotedNewline: Parser[String] = "\\\n".p map ignore
+    def quotedBackslash: Parser[String] = "\\\\".p map const("\\")
+    def backslash: Parser[String] = "\\".p map ignore
+    def whitespace: Parser[String] = """\s""".r map const(" ")
+    def ident: Parser[String] = "[^]]".r map identity
+
+    quotedClosingBracket | quotedNewline | quotedBackslash | backslash | whitespace | ident
+  }
+
+  private def const[A](a: A)(ignore: Any) = a
+}

--- a/exercises/sgf-parsing/src/main/scala/Sgf.scala
+++ b/exercises/sgf-parsing/src/main/scala/Sgf.scala
@@ -1,0 +1,17 @@
+import scala.util.parsing.combinator.RegexParsers
+
+object Sgf extends RegexParsers {
+
+  type Tree[A] = Node[A] // to separate the type from the constructor, cf. Haskell's Data.Tree
+  type Forest[A] = List[Tree[A]]
+  case class Node[A](rootLabel: A, subForest: Forest[A] = List())
+
+  // A tree of nodes.
+  type SgfTree = Tree[SgfNode]
+
+  // A node is a property list, each key can only occur once.
+  // Keys may have multiple values associated with them.
+  type SgfNode = Map[String, List[String]]
+
+  def parseSgf(text: String): Option[SgfTree] = ???
+}

--- a/exercises/sgf-parsing/src/test/scala/SgfTest.scala
+++ b/exercises/sgf-parsing/src/test/scala/SgfTest.scala
@@ -1,0 +1,66 @@
+import org.scalatest.{FunSuite, Matchers}
+import Sgf._
+
+class SgfTest extends FunSuite with Matchers {
+  test("parse \"\"") {
+    Sgf.parseSgf("") should be (None)
+  }
+
+  test("parse \"()\"") {
+    pending
+    Sgf.parseSgf("()") should be (None)
+  }
+
+  test("parse \";\"") {
+    pending
+    Sgf.parseSgf(";") should be (None)
+  }
+
+  test("parse \"(;)\"") {
+    pending
+    Sgf.parseSgf("(;)") should be (Some(Node(Map())))
+  }
+
+  test("parse \"(;A[B])\"") {
+    Sgf.parseSgf("(;A[B])") should be (Some(Node(Map("A" -> List("B")))))
+  }
+
+  test("parse \"(;a)\"") {
+    pending
+    Sgf.parseSgf("(;a)") should be (None)
+  }
+
+  test("parse \"(;a[b])\"") {
+    pending
+    Sgf.parseSgf("(;a[b])") should be (None)
+  }
+
+  test("parse \"(;Aa[b])\"") {
+    pending
+    Sgf.parseSgf("(;Aa[b])") should be (None)
+  }
+
+  test("parse \"(;A[B];B[C])\"") {
+    pending
+    Sgf.parseSgf("(;A[B];B[C])") should be (
+        Some(Node(Map("A" -> List("B")), List(Node(Map("B" -> List("C")))))))
+  }
+
+  test("parse \"(;A[B](;B[C])(;C[D]))\"") {
+    pending
+    Sgf.parseSgf("(;A[B](;B[C])(;C[D]))") should be (
+        Some(Node(Map("A" -> List("B")), List(Node(Map("B" -> List("C"))),
+                                              Node(Map("C" -> List("D")))))))
+  }
+
+  test("parse \"(;A[b][c][d])\"") {
+    pending
+    Sgf.parseSgf("(;A[b][c][d])") should be (Some(Node(Map("A" -> List("b", "c", "d")))))
+  }
+
+  test("""parse "(;A[\\]b\nc\\\nd\t\te\\\\ \\\n\\]])"""") {
+    pending
+    Sgf.parseSgf("(;A[\\]b\nc\\\nd\t\te\\\\ \\\n\\]])") should be (
+        Some(Node(Map("A" -> List("]b cd  e\\ ]")))))
+  }
+}


### PR DESCRIPTION
I decided to just use `scala-parser-combinators` in `Sgf.scala`. We could of course remove it if we don't want to prescribe any library.
And I followed Haskell's [Data.Tree](https://hackage.haskell.org/package/containers-0.5.8.1/docs/Data-Tree.html) library to add an extra type alias `type Tree[A] = Node[A]` in order to separate the type from the type constructor. If this is too confusing we could omit this extra type alias and rename the case class `Node` to `Tree`.