### PR TITLE
Connect: update readme to clarify that not all games are 'fair'

### DIFF
--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -1,0 +1,17 @@
+# Connect
+
+Determine a winner.
+
+The Scala exercises assume an SBT project scheme. The exercise solution source should be placed within the exercise directory/src/main/scala. The exercise unit tests can be found within the exercise directory/src/test/scala.
+
+To run the tests simply run the command `sbt test` in the exercise directory.
+
+For more detailed info about the Scala track see the [help page](http://help.exercism.io/getting-started-with-scala.html).
+
+### Note
+
+You may notice that some test cases seem unfair. However, they may be legitimately so. For example, it is common to give young or beginner players an extra n pieces at fixed positions on the board, so mismatched piece counts can occur in an otherwise fully legal game.
+
+In any case, this exercise cares only about determining a winner for a game that can have a variety of parameters, like board length and extra pieces. It is not interested in any other state of the game, such as who moved where, when, or whose turn it is.
+
+So don't be puzzled by those seemingly unfair games.


### PR DESCRIPTION
Update the README to talk about the contexts in which unequal games make sense.

Related to issue https://github.com/exercism/x-common/issues/212.