### PR TITLE
git ignore IntelliJ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.beam
 *.swp
 .DS_Store
+.idea
 tmp
 target/
 bin/configlet


### PR DESCRIPTION
When modifying existing exercises, I usually use the IntelliJ editor to code in. To prevent someone (read: me) from accidentally committing an IntelliJ configuration directory into this repository, I've added it to the `.gitignore` file.