### PR TITLE
new exercise run-length-encoding

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,6 +29,15 @@
       ]
 		},
     {
+      "slug": "run-length-encoding",
+      "difficulty": 1,
+      "topics": [
+	    "Algorithms",
+	    "Transforming",
+            "Strings"
+      ]
+		},
+    {
       "slug": "hamming",
       "difficulty": 2,
       "topics": [

--- a/exercises/run-length-encoding/build.sbt
+++ b/exercises/run-length-encoding/build.sbt
@@ -1,0 +1,3 @@
+scalaVersion := "2.12.1"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/exercises/run-length-encoding/example.scala
+++ b/exercises/run-length-encoding/example.scala
@@ -1,0 +1,32 @@
+object RunLengthEncoding {
+  type Plain = String
+  type Encoded = String
+
+  def encode(str: Plain): Encoded = {
+    def encodeGroup(xs: Seq[Char]): Seq[Char] =
+      if (xs.length > 1) s"${xs.length}${xs.head}"
+      else xs mkString
+
+    splitByEquals(str) flatMap encodeGroup mkString
+  }
+
+  def decode(str: Encoded): Plain = {
+    val nextChar: ((Int, Seq[Char]), Char) => (Int, Seq[Char]) = {
+      case ((n, xs), x) =>
+        if (x.isDigit) (n * 10 + x.asDigit, xs)
+        else if (n == 0) (0, x +: xs)
+        else (0, Seq.fill(n)(x) ++ xs)
+    }
+
+    val result = str.foldLeft((0, Seq.empty[Char]))(nextChar)
+    result._2.reverse mkString
+  }
+
+  private def splitByEquals[T](xs: Seq[T]): Seq[Seq[T]] =
+    xs match {
+      case Seq() => Seq()
+      case x +: xss =>
+        val fs = xs takeWhile (_ == x)
+        fs +: splitByEquals(xs drop fs.length)
+    }
+}

--- a/exercises/run-length-encoding/src/main/scala/RunLengthEncoding.scala
+++ b/exercises/run-length-encoding/src/main/scala/RunLengthEncoding.scala
@@ -1,0 +1,6 @@
+object RunLengthEncoding {
+
+  def encode(str: String): String = ???
+
+  def decode(str: String): String = ???
+}

--- a/exercises/run-length-encoding/src/test/scala/RunLengthEncodingTests.scala
+++ b/exercises/run-length-encoding/src/test/scala/RunLengthEncodingTests.scala
@@ -1,0 +1,52 @@
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+class RunLengthEncodingTests extends FunSuite with Matchers {
+
+  test("encode empty string") {
+    RunLengthEncoding.encode("") should be ("")
+  }
+
+  test("encode single characters only") {
+    pending
+    RunLengthEncoding.encode("XYZ") should be ("XYZ")
+  }
+
+  test("decode empty string") {
+    pending
+    RunLengthEncoding.decode("") should be ("")
+  }
+
+  test("decode single characters only") {
+    pending
+    RunLengthEncoding.decode("XYZ") should be ("XYZ")
+  }
+
+  test("encode simple") {
+    pending
+    RunLengthEncoding.encode("AABBBCCCC") should be ("2A3B4C")
+  }
+
+  test("decode simple") {
+    pending
+    RunLengthEncoding.decode("2A3B4C") should be ("AABBBCCCC")
+  }
+
+  test("encode with single values") {
+    pending
+    RunLengthEncoding.encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB") should
+      be ("12WB12W3B24WB")
+  }
+
+  test("decode with single values") {
+    pending
+    RunLengthEncoding.decode("12WB12W3B24WB") should be ("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
+  }
+
+  test("decode(encode(...)) combination") {
+    pending
+    RunLengthEncoding.decode(
+        RunLengthEncoding.encode("zzz ZZ  zZ")) should be ("zzz ZZ  zZ")
+  }
+
+}


### PR DESCRIPTION
As always I am not sure where to put this exercise in `config.json`.
Assuming we keep this exercises near to the top I provided a stub with the function signatures instead of an empty `.keep` file.