### PR TITLE
Trinary - Update to Scala 2.12.1 - refs #235.

### DIFF
--- a/exercises/trinary/build.sbt
+++ b/exercises/trinary/build.sbt
@@ -1,3 +1,3 @@
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.1"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"


### PR DESCRIPTION
Update to Scala 2.12.1 - refs #235.

Note that Trinary is actually deprecated.. So, there probably wasn't much reason to update the build.sbt. But it was easy to do...