### PR TITLE
SpaceAge - Update to Scala 2.12.1 - refs #235. Rename SpaceAgeSpecs t…

### DIFF
--- a/exercises/space-age/build.sbt
+++ b/exercises/space-age/build.sbt
@@ -1,3 +1,3 @@
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.1"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/exercises/space-age/src/test/scala/SpaceAgeTest.scala
+++ b/exercises/space-age/src/test/scala/SpaceAgeTest.scala
@@ -1,6 +1,6 @@
 import org.scalatest._
 
-class SpaceAgeSpecs extends FunSuite with Matchers {
+class SpaceAgeTest extends FunSuite with Matchers {
   test ("age in seconds") {
     val age = SpaceAge(1000000)
     age.seconds should be (1000000)


### PR DESCRIPTION
Update to Scala 2.12.1 - refs #235. 
Rename SpaceAgeSpecs to SpaceAgeTest.