### PR TITLE
Bob - Update to Scala 2.12.1 - refs #235. Rename specs to test for co…

### DIFF
--- a/exercises/bob/build.sbt
+++ b/exercises/bob/build.sbt
@@ -1,3 +1,3 @@
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.1"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/exercises/bob/src/test/scala/BobTest.scala
+++ b/exercises/bob/src/test/scala/BobTest.scala
@@ -1,6 +1,6 @@
 import org.scalatest._
 
-class BobSpecs extends FlatSpec with Matchers {
+class BobTest extends FlatSpec with Matchers {
   def teenager = new Bob
 
   it should "respond to a statement" in {


### PR DESCRIPTION
Update to Scala 2.12.1 - refs #235. 
Rename specs to test for consistency with other exercises.