### PR TITLE
Add some detail to INSTALLATION.md. And, update required Java version…

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,5 +1,21 @@
 ## Installing [Scala](http://www.scala-lang.org)
 
-* [Download](http://www.java.com/en/) and install the Java runtime version 1.6 or later
-* [Download](http://www.scala-sbt.org/release/docs/Getting-Started/Setup.html) and install the Simple Build Tool (`sbt`)
 
+In addition to the exercism CLI and your favorite text editor, practicing with Exercism exercises in Scala requires:
+
+* Recent build of the Java 8 Platform, such as [OpenJDK](http://openjdk.java.net/install/) or [Oracle Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 
+* [Download](http://www.scala-sbt.org/release/docs/Setup.html) and install the Simple Build Tool (`sbt`)
+
+---
+
+After installing Java and `sbt` you will be ready to get started with the Scala track of Exercism.
+
+To get started, see "[Running the Tests](http://exercism.io/languages/scala/tests)".
+
+---
+
+# Scala IDEs
+
+* [IntelliJ IDEA with Scala Plugin](https://www.jetbrains.com/idea/)
+* [ScalaIDE](http://scala-ide.org/index.html)
+* [NetBeans with Scala Plugin](https://netbeans.org/)


### PR DESCRIPTION
Add some detail to INSTALLATION.md. 
And, update required Java version.
Refs #248

This is modeled off Java INSTALLATION.md. Though much simplified.

I looked at the Java version and the C# version. In both cases they go into great detail on how to install the needed tools. This seems really heavy weight to me. I would rather redirect users to other resources for hints on how to install Java, sbt, and IDEs. Documenting this stuff ourselves seems like we would be duplicating effort best done by Java, sbt and IDE teams..