### PR TITLE
[WIP] Add TestBuilder

### DIFF
--- a/testgen/src/main/scala/CustomSetTestGenerator.scala
+++ b/testgen/src/main/scala/CustomSetTestGenerator.scala
@@ -2,7 +2,7 @@ import play.api.libs.json.Json
 
 import scala.io.Source
 
-// Generates test suite from json test definitionfor the CustomSet exercise.
+// Generates test suite from json test definition for the CustomSet exercise.
 class CustomSetTestGenerator {
   implicit val emptyTestCaseReader = Json.reads[EmptyTestCase]
   implicit val containsTestCasesReader = Json.reads[ContainsTestCase]
@@ -19,175 +19,211 @@ class CustomSetTestGenerator {
   private val json = Json.parse(fileContents)
 
   def write {
-    print("import org.scalatest.{FunSuite, Matchers}" + System.lineSeparator())
-    print(System.lineSeparator())
-    print("class CustomSetTest extends FunSuite with Matchers {" + System.lineSeparator())
-
-    writeEmptyTests()
-    writeContainsTests()
-    writeSubsetTests()
-    writeDisjointTests()
-    writeEqualTests()
-    writeAddTests()
-    writeIntersectionTests()
-    writeDifferenceTests()
-    writeUnionTests()
-
-    print("}" + System.lineSeparator())
+    val testBuilder = new TestBuilder("CustomSetTest")
+    addEmptyTests(testBuilder)
+    addContainsTests(testBuilder)
+    addSubsetTests(testBuilder)
+    addDisjointTests(testBuilder)
+    addEqualTests(testBuilder)
+    addAddTests(testBuilder)
+    addIntersectionTests(testBuilder)
+    addDifferenceTests(testBuilder)
+    addUnionTests(testBuilder)
+    testBuilder.toFile
   }
 
-  private def writeEmptyTests(): Unit = {
-    println("// Empty test cases - " +  (json \ "empty" \ "description").get.as[String])
+  private def addEmptyTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Empty test cases - " +  (json \ "empty" \ "description").get.as[String]
 
     val emptyTestCases = (json \ "empty" \ "cases").get.as[List[EmptyTestCase]]
 
-    emptyTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: EmptyTestCase): TestCaseGen = {
+      val set = s"CustomSet.fromList(${tc.set})"
+      val callSUT = s"CustomSet.empty(set)"
+      val expected = tc.expected.toString
+      val result = s"val set = $callSUT"
+      val checkResult = s"$callSUT should be ($expected)"
 
-      println("val set = CustomSet.fromList(" + tc.set + ")")
-      println("CustomSet.empty(set) should be (" + tc.expected + ")")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(emptyTestCases, Some(description))
   }
 
-  private def writeContainsTests(): Unit = {
-    println("// Contains test cases - " +  (json \ "contains" \ "description").get.as[String])
+  private def addContainsTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Contains test cases - " + (json \ "contains" \ "description").get.as[String]
 
     val containsTestCases = (json \ "contains" \ "cases").get.as[List[ContainsTestCase]]
 
-    containsTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: ContainsTestCase): TestCaseGen = {
+      val set = s"CustomSet.fromList(${tc.set})"
+      val callSUT = s"CustomSet.member(set, ${tc.element})"
+      val expected = tc.expected.toString
+      val result = s"val set = $set"
+      val checkResult = s"$callSUT should be ($expected)"
 
-      println("val set = CustomSet.fromList(" + tc.set + ")")
-      println("CustomSet.member(set, " + tc.element + ") should be (" + tc.expected + ")")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(containsTestCases, Some(description))
   }
 
-  private def writeSubsetTests(): Unit = {
-    println("// Subset test cases - " +  (json \ "subset" \ "description").get.as[String])
+  private def addSubsetTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Subset test cases - " + (json \ "subset" \ "description").get.as[String]
 
     val subsetTestCases = (json \ "subset" \ "cases").get.as[List[SubsetTestCase]]
 
-    subsetTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: SubsetTestCase): TestCaseGen = {
+      val set1 = s"CustomSet.fromList(${tc.set1})"
+      val set2 = s"CustomSet.fromList(${tc.set2})"
+      val callSUT = s"CustomSet.isSubsetOf(set1, set2)"
+      val expected = tc.expected.toString
+      val result =
+s"""val set1 = $set1
+    val set2 = $set2"""
+      val checkResult = s"$callSUT should be ($expected)"
 
-      println("val set1 = CustomSet.fromList(" + tc.set1 + ")")
-      println("val set2 = CustomSet.fromList(" + tc.set2 + ")")
-      println("CustomSet.isSubsetOf(set1, set2) should be (" + tc.expected + ")")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(subsetTestCases, Some(description))
   }
 
-  private def writeDisjointTests(): Unit = {
-    println("// Disjoint test cases - " +  (json \ "disjoint" \ "description").get.as[String])
+  private def addDisjointTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Disjoint test cases - " + (json \ "disjoint" \ "description").get.as[String]
 
     val disjointTestCases = (json \ "disjoint" \ "cases").get.as[List[DisjointTestCase]]
 
-    disjointTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: DisjointTestCase): TestCaseGen = {
+      val set1 = s"CustomSet.fromList(${tc.set1})"
+      val set2 = s"CustomSet.fromList(${tc.set2})"
+      val callSUT = s"CustomSet.isDisjointFrom(set1, set2)"
+      val expected = tc.expected.toString
+      val result =
+s"""val set1 = $set1
+    val set2 = $set2"""
+      val checkResult = s"$callSUT should be ($expected)"
 
-      println("val set1 = CustomSet.fromList(" + tc.set1 + ")")
-      println("val set2 = CustomSet.fromList(" + tc.set2 + ")")
-      println("CustomSet.isDisjointFrom(set1, set2) should be (" + tc.expected + ")")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(disjointTestCases, Some(description))
   }
 
-  private def writeEqualTests(): Unit = {
-    println("// Equal test cases - " +  (json \ "equal" \ "description").get.as[String])
+  private def addEqualTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Equal test cases - " + (json \ "equal" \ "description").get.as[String]
 
     val equalTestCases = (json \ "equal" \ "cases").get.as[List[EqualTestCase]]
 
-    equalTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: EqualTestCase): TestCaseGen = {
+      val set1 = s"CustomSet.fromList(${tc.set1})"
+      val set2 = s"CustomSet.fromList(${tc.set2})"
+      val callSUT = s"CustomSet.isEqual(set1, set2)"
+      val expected = tc.expected.toString
+      val result =
+s"""val set1 = $set1
+    val set2 = $set2"""
+      val checkResult = s"$callSUT should be ($expected)"
 
-      println("val set1 = CustomSet.fromList(" + tc.set1 + ")")
-      println("val set2 = CustomSet.fromList(" + tc.set2 + ")")
-      println("CustomSet.isEqual(set1, set2) should be (" + tc.expected + ")")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(equalTestCases, Some(description))
   }
 
-  private def writeAddTests(): Unit = {
-    println("// Add test cases - " +  (json \ "add" \ "description").get.as[String])
+  private def addAddTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Add test cases - " + (json \ "add" \ "description").get.as[String]
 
     val addTestCases = (json \ "add" \ "cases").get.as[List[AddTestCase]]
 
-    addTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: AddTestCase): TestCaseGen = {
+      val set = s"CustomSet.fromList(${tc.set})"
+      val callSUT = s"CustomSet.insert(set, ${tc.element})"
+      val expected = s"CustomSet.fromList(${tc.expected})"
+      val result =
+s"""val set = $set
+    val expected = $expected"""
+      val checkResult = s"CustomSet.isEqual($callSUT, expected) should be (true)"
 
-      println("val set = CustomSet.fromList(" + tc.set + ")")
-      println("val expected = CustomSet.fromList(" + tc.expected + ")")
-      println("CustomSet.isEqual(CustomSet.insert(set, " +  tc.element + " ), expected) should be (true)")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(addTestCases, Some(description))
   }
 
-  private def writeIntersectionTests(): Unit = {
-    println("// Intersection test cases - " +  (json \ "intersection" \ "description").get.as[String])
+  private def addIntersectionTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Intersection test cases - " + (json \ "intersection" \ "description").get.as[String]
 
     val intersectionTestCases = (json \ "intersection" \ "cases").get.as[List[IntersectionTestCase]]
 
-    intersectionTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: IntersectionTestCase): TestCaseGen = {
+      val set1 = s"CustomSet.fromList(${tc.set1})"
+      val set2 = s"CustomSet.fromList(${tc.set2})"
+      val callSUT = s"CustomSet.intersection(set1, set2)"
+      val expected = s"CustomSet.fromList(${tc.expected})"
+      val result =
+s"""val set1 = $set1
+    val set2 = $set2
+    val expected = $expected"""
+      val checkResult = s"CustomSet.isEqual($callSUT, expected) should be (true)"
 
-      println("val set1 = CustomSet.fromList(" + tc.set1 + ")")
-      println("val set2 = CustomSet.fromList(" + tc.set2 + ")")
-      println("val expected = CustomSet.fromList(" + tc.expected + ")")
-      println("CustomSet.isEqual(CustomSet.intersection(set1, set2), expected) should be (true)")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(intersectionTestCases, Some(description))
   }
 
-  private def writeDifferenceTests(): Unit = {
-    println("// Difference test cases - " +  (json \ "difference" \ "description").get.as[String])
+  private def addDifferenceTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Difference test cases - " + (json \ "difference" \ "description").get.as[String]
 
     val differenceTestCases = (json \ "difference" \ "cases").get.as[List[DifferenceTestCase]]
 
-    differenceTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: DifferenceTestCase): TestCaseGen = {
+      val set1 = s"CustomSet.fromList(${tc.set1})"
+      val set2 = s"CustomSet.fromList(${tc.set2})"
+      val callSUT = s"CustomSet.difference(set1, set2)"
+      val expected = s"CustomSet.fromList(${tc.expected})"
+      val result =
+s"""val set1 = $set1
+    val set2 = $set2
+    val expected = $expected"""
+      val checkResult = s"CustomSet.isEqual($callSUT, expected) should be (true)"
 
-      println("val set1 = CustomSet.fromList(" + tc.set1 + ")")
-      println("val set2 = CustomSet.fromList(" + tc.set2 + ")")
-      println("val expected = CustomSet.fromList(" + tc.expected + ")")
-      println("CustomSet.isEqual(CustomSet.difference(set1, set2), expected) should be (true)")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(differenceTestCases, Some(description))
   }
 
-  private def writeUnionTests(): Unit = {
-    println("// Union test cases - " +  (json \ "union" \ "description").get.as[String])
+  private def addUnionTests(testBuilder: TestBuilder): Unit = {
+    val description =
+      "Union test cases - " + (json \ "union" \ "description").get.as[String]
 
-    val differenceTestCases = (json \ "union" \ "cases").get.as[List[UnionTestCase]]
+    val unionTestCases = (json \ "union" \ "cases").get.as[List[UnionTestCase]]
 
-    differenceTestCases.foreach(tc => {
-      print("\ttest(\"" + tc.description + "\") {" + System.lineSeparator())
+    implicit def testCaseToGen(tc: UnionTestCase): TestCaseGen = {
+      val set1 = s"CustomSet.fromList(${tc.set1})"
+      val set2 = s"CustomSet.fromList(${tc.set2})"
+      val callSUT = s"CustomSet.union(set1, set2)"
+      val expected = s"CustomSet.fromList(${tc.expected})"
+      val result =
+s"""val set1 = $set1
+    val set2 = $set2
+    val expected = $expected"""
+      val checkResult = s"CustomSet.isEqual($callSUT, expected) should be (true)"
 
-      println("val set1 = CustomSet.fromList(" + tc.set1 + ")")
-      println("val set2 = CustomSet.fromList(" + tc.set2 + ")")
-      println("val expected = CustomSet.fromList(" + tc.expected + ")")
-      println("CustomSet.isEqual(CustomSet.union(set1, set2), expected) should be (true)")
+      TestCaseGen(tc.description, callSUT, expected, result, checkResult)
+    }
 
-      print("\t}" + System.lineSeparator())
-      print(System.lineSeparator())
-    })
+    testBuilder.addTestCases(unionTestCases, Some(description))
   }
 
 }

--- a/testgen/src/main/scala/TestBuilder.scala
+++ b/testgen/src/main/scala/TestBuilder.scala
@@ -1,0 +1,86 @@
+import java.io.FileWriter
+import java.io.File
+
+case class TestCaseGen(description: String, callSUT: String, expected: String,
+    result: String, checkResult: String)
+
+object TestCaseGen {
+  def apply(description: String, callSUT: String, expected: String): TestCaseGen =
+    TestCaseGen(description, callSUT, expected,
+        s"val result = $callSUT", s"result should be ($expected)")
+
+  implicit def toTestCaseGenSeq[T](ts: Seq[T])(
+      implicit toGen: T => TestCaseGen): Seq[TestCaseGen] =
+    ts map toGen
+}
+
+class TestBuilder(testName: String) {
+
+  private var imports: Seq[String] = Seq()
+  def addImport(imprt: String): Unit = imports = imports :+ imprt
+
+  private var testCases: Seq[(Seq[TestCaseGen], Option[String])] = Seq()
+  def addTestCases(testCases: Seq[TestCaseGen], description: Option[String] = None): Unit =
+    this.testCases = this.testCases :+ (testCases, description)
+
+  def toFile: Unit = {
+    val file = new File(s"$testName.scala")
+    val fileWriter = new FileWriter(file)
+    try { fileWriter.write(build) } finally fileWriter.close
+
+    println(s"file ${file.getAbsolutePath} created")
+  }
+
+  def build: String =
+s"""$printImports
+class $testName extends FunSuite with Matchers {
+$printTestCases
+}
+"""
+
+  private lazy val printImports: String =
+    "import org.scalatest.{FunSuite, Matchers}\n" +
+    (imports map (imp => s"import $imp\n") mkString)
+
+  private lazy val printTestCases: String = {
+    var pending = false
+    def printPending: String =
+      if (pending) s"pending\n    " else { pending = true; "" }
+
+    def printTestCaseGroup(testCaseGroup: Seq[TestCaseGen],
+        groupDescription: Option[String]): String =
+    {
+      val description = groupDescription map (s => s"\n  // $s") getOrElse ""
+      val testCases = testCaseGroup map printTestCase mkString
+
+      s"$description$testCases"
+    }
+
+    def printTestCase(tc: TestCaseGen): String =
+s"""
+  test("${tc.description}") {
+    ${printPending}${tc.result}
+    ${tc.checkResult}
+  }
+"""
+
+    testCases map (printTestCaseGroup _).tupled mkString
+  }
+}
+
+object TestBuilder {
+  def main(args: Array[String]): Unit = {
+    val testCases13 =
+      (1 to 3) map (i => TestCaseGen(s"test$i", s"identity($i)", s"$i"))
+    val testCases45 =
+      (4 to 5) map (i => TestCaseGen(s"test$i", s"identity($i)", s"$i"))
+    val tb = new TestBuilder("IdentityTest")
+    tb.addImport("scala.collection.mutable")
+    tb.addTestCases(testCases13, Some("identity tests 1-3"))
+    tb.addTestCases(testCases45)
+    println("-----")
+    println(tb.build)
+    println("-----")
+    tb.toFile
+  }
+}


### PR DESCRIPTION
This is a first attempt on issue #331 

There is a new class `TestBuilder` (a DSL would probably be more Scala-like than the builder pattern, but the latter was straightforward and less time-consuming).

To use it one has to provide an `implicit def` to translate a test case into a `TestCaseGen`.
An example would be `AllYourBaseTestGenerator.testCaseToGen`.

Please let me know what you think.

(perhaps something similar can be done at the json parser side?)