### PR TITLE
simple-linked-list: Add missing scalacheck library

### DIFF
--- a/exercises/simple-linked-list/build.sbt
+++ b/exercises/simple-linked-list/build.sbt
@@ -1,3 +1,6 @@
 scalaVersion := "2.12.1"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
+


### PR DESCRIPTION
ScalaTest does not include ScalaCheck by default.
In order to use it one has to include it explicitly.