### PR TITLE
simple-linked-list: Add property-based test for add

### DIFF
--- a/exercises/simple-linked-list/src/test/scala/SimpleLinkedListTest.scala
+++ b/exercises/simple-linked-list/src/test/scala/SimpleLinkedListTest.scala
@@ -61,7 +61,7 @@ class SimpleLinkedListTest extends FlatSpec with Matchers with GeneratorDrivenPr
     reversed.next.next.next.next.value should be (2)
     reversed.next.next.next.next.next.value should be (1)
   }
-  
+
   it should "handle arbitrary list fromSeq toSeq" in {
     pending
     forAll { seq: Seq[Int] =>
@@ -96,6 +96,14 @@ class SimpleLinkedListTest extends FlatSpec with Matchers with GeneratorDrivenPr
           i => assert(nthDatum(list, i) == xs(i))
         }
       }
+    }
+  }
+
+  it should "return original arbitrary list from added list elements" in {
+    pending
+    forAll { xs: Seq[Int] =>
+      val list = xs.foldLeft(SimpleLinkedList[Int]())(_.add(_))
+      assert(list.toSeq == xs)
     }
   }
 


### PR DESCRIPTION
This property-based test for `SimpleLinkedList.add` gave me a `StackOverflowError` for my first solution attempt, and I had to make it tail-recursive.

So I think it makes sense to add it to the test suite.