### PR TITLE
Add a modification of non ascii chars test without character x

### DIFF
--- a/exercises/pangram/src/test/scala/PangramTest.scala
+++ b/exercises/pangram/src/test/scala/PangramTest.scala
@@ -45,4 +45,9 @@ class PangramsTest extends FunSuite with Matchers {
     Pangrams.isPangram("Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.") should be (true)
   }
 
+  test("pangram with non ascii characters missing character 'x'") {
+    pending
+    Pangrams.isPangram("Victor jagt zwölf Botkämpfer quer über den großen Sylter Deich.") should be (false)
+  }
+
 }


### PR DESCRIPTION
The base test seems to be modified with the non-ascii test. 

I feel that another useful test would be a string with non-ascii characters, but with a missing character 'x'. This would invalidate solutions that are written to simply pass the previous test (e.g. by making the test for distinct characters be >= 26).