### PR TITLE
Update README.md to reference the Bob example when talking about test…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ suite generators are named in the form `ProblemNameTestGenerator.scala`. Where
 For example, take a look at the `bob/canonical-data.json` file in the x-common repository, as well
 as the following files in the xscala repository:
 
-1. `testgen/src/main/scala/BobTestGenerator.scala` - test suite generator for all-your-base
-1. `exercises/all-your-base/src/test/scala/BobTest.scala`- generated test suite
+1. `testgen/src/main/scala/BobTestGenerator.scala` - test suite generator for bob
+1. `exercises/bob/src/test/scala/BobTest.scala`- generated test suite
 
-Since a generator was used, the`exercises/all-your-base/src/test/scala/BobTest.scala` will never be edited directly. 
+Since a generator was used, the`exercises/bob/src/test/scala/BobTest.scala` will never be edited directly. 
 If there's a missing test case, then additional inputs/outputs should be submitted to the x-common repository.
 
 When submitting new exercises we encourage that a test suite generator and generated test suite is

--- a/README.md
+++ b/README.md
@@ -17,17 +17,14 @@ suite generators are named in the form `ProblemNameTestGenerator.scala`. Where
 
 [the shared problem metadata](https://github.com/exercism/x-common).
 
-For example, take a look at the `all-your-base/canonical-data.json` file in the x-common repository, as well
+For example, take a look at the `bob/canonical-data.json` file in the x-common repository, as well
 as the following files in the xscala repository:
 
-1. `testgen/src/main/scala/AllYourBaseTestGenerator.scala` - test suite generator for all-your-base
-1. `exercises/all-your-base/src/test/scala/AllYourBase.scala`- generated test suite
+1. `testgen/src/main/scala/BobTestGenerator.scala` - test suite generator for all-your-base
+1. `exercises/all-your-base/src/test/scala/BobTest.scala`- generated test suite
 
-Since a generator was used, the`exercises/all-your-base/src/test/scala/AllYourBase.scala` will never be edited directly. 
+Since a generator was used, the`exercises/all-your-base/src/test/scala/BobTest.scala` will never be edited directly. 
 If there's a missing test case, then additional inputs/outputs should be submitted to the x-common repository.
-
-Note that the the test suite generators do not format the test suite source code. The generated test suite should be 
-formatted before being submitted.
 
 When submitting new exercises we encourage that a test suite generator and generated test suite is
 included. 


### PR DESCRIPTION
Update README.md to reference the Bob example when talking about test generators. BobTestGenerator is a much more simple example. And, BobTestGenerator is based off of TestSuiteBuilder which is the preferred method for creating the generators.