### PR TITLE
Add test suite version to beer-song (#370)

### DIFF
--- a/exercises/beer-song/src/test/scala/BeerSongTest.scala
+++ b/exercises/beer-song/src/test/scala/BeerSongTest.scala
@@ -1,5 +1,6 @@
 import org.scalatest._
 
+/** @version 1.0.0 */
 class BeerSongTest extends FunSuite {
 
   test("first generic verse") {

--- a/testgen/src/main/scala/BeerSongTestGenerator.scala
+++ b/testgen/src/main/scala/BeerSongTestGenerator.scala
@@ -11,5 +11,7 @@ object BeerSongTestGenerator {
     println(s"-------------")
     println(code)
     println(s"-------------")
+
+    TestSuiteBuilder.writeToFile(code, new File("BeerSongTest.scala"))
   }
 }

--- a/testgen/src/main/scala/testgen/CanonicalDataParser.scala
+++ b/testgen/src/main/scala/testgen/CanonicalDataParser.scala
@@ -66,7 +66,7 @@ object Exercise {
   private def flattenCases(cases: Cases): Cases =
     cases match {
       case Seq() => Seq()
-      case (ltg: LabeledTestGroup) +: xs => ltg.cases ++ flattenCases(xs)
+      case (ltg: LabeledTestGroup) +: xs => flattenCases(ltg.cases) ++ flattenCases(xs)
       case (lt: LabeledTest) +: xs => lt +: flattenCases(xs)
     }
 }

--- a/testgen/src/main/scala/testgen/TestSuiteBuilder.scala
+++ b/testgen/src/main/scala/testgen/TestSuiteBuilder.scala
@@ -98,7 +98,7 @@ object TestSuiteBuilder {
     }
   }
 
-  def toFile(text: String, dest: File): Unit = {
+  def writeToFile(text: String, dest: File): Unit = {
     val fileWriter = new FileWriter(dest)
     try { fileWriter.write(text) } finally fileWriter.close
   }


### PR DESCRIPTION
- Add version number manually, discarding `BeerSongTestGenerator.scala`'s output (preserved better code layout).
- Fix bug in `CanonicalDataParser.scala` for nested `LabeledTestGroup`s.
- Rename method `toFile` -> `writeToFile` in `TestSuiteBuilder.scala`.