### PR TITLE
Remove sbt version requirement - Fix Issue 637

### DIFF
--- a/exercises/practice/flatten-array/project/build.properties
+++ b/exercises/practice/flatten-array/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.0.3


### PR DESCRIPTION
As mentioned in #637 the build does not work with a different sbt version.
This removes the hard-coded sbt version requirement.

Closes #637