### PR TITLE
Deprecate accumulate exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -768,6 +768,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
+        "status": "deprecated",
         "topics": [
           "generics",
           "lists",


### PR DESCRIPTION
Marks accumulate as deprecated in config.json.
As mentioned in #858, accumulate is deprecated upstream 
and list-ops should be implemented as its replacement.
Related to #858