### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions Append
 
-## Implementation
+## Track specific instructions
 
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/connect/.docs/instructions.append.md
+++ b/exercises/practice/connect/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 You may notice that some test cases seem unfair.
 However, they may be legitimately so.

--- a/exercises/practice/connect/.docs/instructions.append.md
+++ b/exercises/practice/connect/.docs/instructions.append.md
@@ -1,6 +1,12 @@
-# Hints
-You may notice that some test cases seem unfair. However, they may be legitimately so. For example, it is common to give young or beginner players an extra n pieces at fixed positions on the board, so mismatched piece counts can occur in an otherwise fully legal game.
+# Instructions append
 
-In any case, this exercise cares only about determining a winner for a game that can have a variety of parameters, like board length and extra pieces. It is not interested in any other state of the game, such as who moved where, when, or whose turn it is.
+## Hints
+
+You may notice that some test cases seem unfair.
+However, they may be legitimately so.
+For example, it is common to give young or beginner players an extra n pieces at fixed positions on the board, so mismatched piece counts can occur in an otherwise fully legal game.
+
+In any case, this exercise cares only about determining a winner for a game that can have a variety of parameters, like board length and extra pieces.
+It is not interested in any other state of the game, such as who moved where, when, or whose turn it is.
 
 So don't be puzzled by those seemingly unfair games.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 Note that `addGigaseconds` accepts two different types of input.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,2 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
+
 Note that `addGigaseconds` accepts two different types of input.

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,4 +1,8 @@
 # Hints
+
+## Implementation
+
 Try to avoid code repetition, use private helper functions if you can.
 
-And you might consider using a single `Boolean` expression instead of `if-else` for better readability. See [here](http://cs.wellesley.edu/~cs111/spring00/lectures/boolean-simplification.html) on how this could be done (the link is for Java, but of course the logic is valid for Scala, too).
+And you might consider using a single `Boolean` expression instead of `if-else` for better readability.
+See [here](http://cs.wellesley.edu/~cs111/spring00/lectures/boolean-simplification.html) on how this could be done (the link is for Java, but of course the logic is valid for Scala, too).

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Hints
 
-## Implementation
+## Track specific instructions
 
 Try to avoid code repetition, use private helper functions if you can.
 

--- a/exercises/practice/lens-person/.docs/instructions.append.md
+++ b/exercises/practice/lens-person/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 In Scala, a popular alternative for using Lens that is supported by Exercism is [Monocle](https://www.optics.dev/Monocle/)

--- a/exercises/practice/lens-person/.docs/instructions.append.md
+++ b/exercises/practice/lens-person/.docs/instructions.append.md
@@ -1,2 +1,5 @@
-In Scala, a popular alternative for using Lens that is supported
-by Exercism is [Monocle](https://www.optics.dev/Monocle/)
+# Instructions append
+
+## Implementation
+
+In Scala, a popular alternative for using Lens that is supported by Exercism is [Monocle](https://www.optics.dev/Monocle/)

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,26 +1,30 @@
-# Hints
-According to [this terminology](http://chimera.labs.oreilly.com/books/1230000000929/ch01.html#sec_terminology) you should write a *parallel* and *deterministic*
-program and (by all means!) let Scala deal with the *concurrency* aspect.
-Or else your code could quickly get messy and error-prone with all kinds of nasty
-concurrency bugs. In particular your program could become indeterministic
-which spells in practice: very (in fact, VERY) hard to debug, test and reason about.
+# Instructions append
 
-Having said that it might be a good idea to first write a sequential solution (and
-use the test suite to verify it).
-Only then should you try to parallelize it while keeping the sequential and parallel
-portions of your code as separate as possible.
+## Hints
 
-A first iteration could be using Scala's [parallel collections](http://docs.scala-lang.org/overviews/parallel-collections/overview.html). You might find
-that this is almost too simple (especially if you have followed our advice and
-already have a sequential solution).
+According to [this terminology][terminology] you should write a *parallel* and *deterministic* program and (by all means!) let Scala deal with the *concurrency* aspect.
+Or else your code could quickly get messy and error-prone with all kinds of nasty concurrency bugs.
+In particular your program could become indeterministic which spells in practice: very (in fact, VERY) hard to debug, test and reason about.
 
-For the second iteration we recommend you try a solution with [scala.concurrent.Future](http://www.scala-lang.org/api/current/scala/concurrent/Future$.html).
-You can consult [this tutorial](http://danielwestheide.com/blog/2013/01/09/the-neophytes-guide-to-scala-part-8-welcome-to-the-future.html) and [its sequel](http://danielwestheide.com/blog/2013/01/16/the-neophytes-guide-to-scala-part-9-promises-and-futures-in-practice.html) for some help.
+Having said that it might be a good idea to first write a sequential solution (and use the test suite to verify it).
+Only then should you try to parallelize it while keeping the sequential and parallel portions of your code as separate as possible.
+
+A first iteration could be using Scala's [parallel collections].
+You might find that this is almost too simple (especially if you have followed our advice and already have a sequential solution).
+
+For the second iteration we recommend you try a solution with [`scala.concurrent.Future`][Future].
+You can consult [this tutorial][tutorial] and [its sequel][sequel] for some help.
 Make sure that you
+
 - have only one single blocking call to wait for the result
 - that it is at the very end of your program, and
 - that it has a timeout.
 
-`scala.concurrent.Future` is used in many libraries and the doctor's advice for
-parallel and asynchronous programming in Scala. So it is essential for mastering
-the language and it should become part of your Scala armory.
+`scala.concurrent.Future` is used in many libraries and the doctor's advice for parallel and asynchronous programming in Scala.
+So it is essential for mastering the language and it should become part of your Scala armory.
+
+[terminology]: http://chimera.labs.oreilly.com/books/1230000000929/ch01.html#sec_terminology
+[parallel collections]: http://docs.scala-lang.org/overviews/parallel-collections/overview.html
+[Future]: http://www.scala-lang.org/api/current/scala/concurrent/Future$.html
+[tutorial]: http://danielwestheide.com/blog/2013/01/09/the-neophytes-guide-to-scala-part-8-welcome-to-the-future.html
+[sequel]: http://danielwestheide.com/blog/2013/01/16/the-neophytes-guide-to-scala-part-9-promises-and-futures-in-practice.html

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 According to [this terminology][terminology] you should write a *parallel* and *deterministic* program and (by all means!) let Scala deal with the *concurrency* aspect.
 Or else your code could quickly get messy and error-prone with all kinds of nasty concurrency bugs.

--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,9 +1,14 @@
-# Hints
-For simplicity and readability: Consider using the Scala collection functions instead of Java's `String` methods. Remember that in Scala a `String` is implicitly also a `Seq[Char]`, so you can call them as easily as the `String` methods.
+# Instructions append
+
+## Hints
+
+For simplicity and readability: Consider using the Scala collection functions instead of Java's `String` methods.
+Remember that in Scala a `String` is implicitly also a `Seq[Char]`, so you can call them as easily as the `String` methods.
 
 Some examples:
 - `filter` instead of `replaceAll`
 - `take`, `takeRight`, `drop`, `head`, `tail` instead of `substring`
 
-Another idea worth exploring might be to change the `String` into a `List[Char]`
-and then use [pattern matching](http://alvinalexander.com/scala/how-to-use-lists-nil-cons-scala-match-case-expressions) with the `::` operator.
+Another idea worth exploring might be to change the `String` into a `List[Char]` and then use [pattern matching] with the `::` operator.
+
+[pattern matching]: http://alvinalexander.com/scala/how-to-use-lists-nil-cons-scala-match-case-expressions

--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 For simplicity and readability: Consider using the Scala collection functions instead of Java's `String` methods.
 Remember that in Scala a `String` is implicitly also a `Seq[Char]`, so you can call them as easily as the `String` methods.

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 Make sure your solution is general enough to be easily scalable for longer names containing more letters and digits.
 This usually makes for better code quality, too.

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,5 +1,9 @@
-# Hints
-Make sure your solution is general enough to be easily scalable for longer names containing more letters and digits. This usually makes for better code quality, too.
+# Instructions append
+
+## Hints
+
+Make sure your solution is general enough to be easily scalable for longer names containing more letters and digits.
+This usually makes for better code quality, too.
 
 Suggestion (this is not explicitly tested):
 To make sure you always have a unique name you could implement your own cache or use a `Stream` with its built-in cache.

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,4 +1,7 @@
-# Hints
+# Instructions append
+
+## Hints
+
 For something a little different you might also try a solution with an `unfold` function.
 You are probably already familiar with `foldLeft/Right`: "map" a whole collection into something else (usually a non-collection).
 `unfoldLeft/Right` are the "inverse" operations: "map" something (usually a non-collection) into a collection.
@@ -7,4 +10,6 @@ So `unfold`ing is a logical addition to and part of the FP standard repertoire.
 This exercise can be seen as a case for `unfold`ing: "map" an `Int` into a `String` (which is of course implicitly a `Seq[Char]`).
 
 Unfortunately `unfoldLeft/Right` is not included in Scala's collection library.
-But you can take the implementation from [here](http://daily-scala.blogspot.de/2009/09/unfoldleft-and-right.html).
+But you can take the implementation from [here][unfold].
+
+[unfold]: http://daily-scala.blogspot.de/2009/09/unfoldleft-and-right.html

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 For something a little different you might also try a solution with an `unfold` function.
 You are probably already familiar with `foldLeft/Right`: "map" a whole collection into something else (usually a non-collection).

--- a/exercises/practice/variable-length-quantity/.docs/instructions.append.md
+++ b/exercises/practice/variable-length-quantity/.docs/instructions.append.md
@@ -1,2 +1,6 @@
-# Hints
-Remember that in Scala there are two forms of the right shift operator. The `>>` operator preserves the sign, while `>>>` zeroes the leftmost bits.
+# Instructions append
+
+## Hints
+
+Remember that in Scala there are two forms of the right shift operator.
+The `>>` operator preserves the sign, while `>>>` zeroes the leftmost bits.

--- a/exercises/practice/variable-length-quantity/.docs/instructions.append.md
+++ b/exercises/practice/variable-length-quantity/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 Remember that in Scala there are two forms of the right shift operator.
 The `>>` operator preserves the sign, while `>>>` zeroes the leftmost bits.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.